### PR TITLE
feat(transform): normalization strategies and classification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentação do Projeto
+
+Este diretório contém toda a documentação vital do projeto `retrieve_edital`. A manutenção atualizada destes arquivos garante a sustentabilidade arquitetural do robô de Extração da FAPES.
+
+## Índice de Documentos
+
+### Arquitetura e Regras
+- [Diretrizes de Desenvolvimento S.O.L.I.D](development_guidelines.md)
+  - Descreve as premissas inegociáveis do repositório (OOP Estrito, Clean Code, Anti-padrões mapeados).
+- [Arquitetura ETL (System Design Document)](etl_architecture.md)
+  - Descreve o padrão T-Shape (`Source` -> `Transform` -> `Sink`) e como os dados fluem desde a coleta até o arquivo JSON final.
+
+### Ágil e Produto
+- [Product Backlog](backlog.md)
+  - Visão detalhada de Epics, User Stories e Tasks. Linkado ativamente com a central de Issues do GitHub no formato sprint.
+
+### Testes Baseados em Comportamento (BDD)
+Os arquivos a seguir (`.feature` em Gherkin) são a principal fonte de verdade sobre o comportamento esperado da nossa pipeline técnica e atuam como contrato obrigatório *(Definition of Done)* para aceitação de pull requests:
+- [Extração (Extract)](features/extract_editais.feature)
+- [Transformação (Transform)](features/transform_editais.feature)
+- [Persistência (Load/Sink)](features/load_editais.feature)

--- a/src/components/transforms/edital_normalizer.py
+++ b/src/components/transforms/edital_normalizer.py
@@ -1,0 +1,49 @@
+import re
+from typing import List
+from src.core.interfaces import ITransform
+from src.domain.models import RawEdital, EditalDomain
+
+class EditalNormalizer(ITransform[RawEdital, EditalDomain]):
+    """
+    Normalizes the RawEdital data into a validated EditalDomain object.
+    Applies regex cleaning and basic business rules for categorization.
+    """
+    
+    def process(self, raw_data: RawEdital) -> EditalDomain:
+        # Mandatory validation
+        if not raw_data.title or raw_data.title.strip() == "":
+            raise ValueError("O título do edital não pode ser nulo ou vazio.")
+
+        # Title normalization: remove extra spaces and newlines
+        clean_title = re.sub(r'\s+', ' ', raw_data.title).strip().upper()
+
+        # Agency standardization
+        raw_orgao = (raw_data.raw_agency or "FAPES").upper()
+        if "FAPES" in raw_orgao:
+            clean_agency = "FAPES"
+        elif "CNPQ" in raw_orgao:
+            clean_agency = "CNPQ"
+        else:
+            clean_agency = raw_orgao
+
+        # Category extraction by empirical rule on the description
+        description = raw_data.raw_description or ""
+        category = "Outros"
+        if "extensão" in description.lower():
+            category = "Extensão"
+        elif "pesquisa" in description.lower():
+            category = "Pesquisa"
+        elif "inovação" in description.lower():
+            category = "Inovação"
+
+        # Cronograma defaults to empty list of dictionaries if not available from raw
+        # (This avoids the type error and matches the `List[Dict[str, str]]` requirement)
+        cronograma: List[dict] = []
+
+        return EditalDomain(
+            nome_do_edital=clean_title,
+            orgao_de_fomento=clean_agency,
+            cronograma=cronograma,
+            descricao=description,
+            categoria=category
+        )

--- a/tests/step_defs/test_transform_editais.py
+++ b/tests/step_defs/test_transform_editais.py
@@ -1,51 +1,80 @@
 from pytest_bdd import scenarios, given, when, then, parsers
+from src.domain.models import RawEdital, EditalDomain
+from src.components.transforms.edital_normalizer import EditalNormalizer
+import pytest
 
 scenarios("../../docs/features/transform_editais.feature")
 
+@pytest.fixture
+def context():
+    return {"raw_data": None, "transform_engine": None, "result": None, "error": None}
+
 @given('the Transformation engine is ready to receive raw data dictionaries')
-def transform_engine_ready():
-    pass
+def transform_engine_ready(context):
+    context["transform_engine"] = EditalNormalizer()
 
 @given(parsers.parse('a raw edital record with title "{raw_title}" and agency "{raw_agency}"'))
-def raw_edital_record(raw_title, raw_agency):
-    pass
+def raw_edital_record(context, raw_title, raw_agency):
+    context["raw_data"] = RawEdital(
+        title=raw_title,
+        url="http://mock.com",
+        raw_agency=raw_agency
+    )
 
 @when('the Transform component processes the record')
-def transform_processes_record():
-    pass
+def transform_processes_record(context):
+    try:
+        context["result"] = context["transform_engine"].process(context["raw_data"])
+    except Exception as e:
+        context["error"] = e
 
 @then(parsers.parse('the title should be normalized to "{clean_title}"'))
-def title_normalized(clean_title):
-    pass
+def title_normalized(context, clean_title):
+    assert context["result"].nome_do_edital == clean_title
 
 @then(parsers.parse('the funding agency should be standardized to "{clean_agency}"'))
-def agency_standardized(clean_agency):
-    pass
+def agency_standardized(context, clean_agency):
+    assert context["result"].orgao_de_fomento == clean_agency
 
 @then('it should return a valid Edital domain object')
-def valid_edital_domain_object():
-    pass
+def valid_edital_domain_object(context):
+    assert isinstance(context["result"], EditalDomain)
 
 @given('a raw edital contains the description "Apoio a projetos de extensão tecnológica"')
-def raw_edital_with_description():
-    pass
+def raw_edital_with_description(context):
+    context["raw_data"] = RawEdital(
+        title="Valid Title",
+        url="http://mock.com",
+        raw_description="Apoio a projetos de extensão tecnológica"
+    )
+    if not context.get("transform_engine"):
+        context["transform_engine"] = EditalNormalizer()
 
 @then('the business logic should classify and set the "category" field as "Extensão"')
-def category_is_extensao():
-    pass
+def category_is_extensao(context):
+    assert context["result"].categoria == "Extensão"
 
 @given('a raw record failed extraction and has an empty title')
-def record_empty_title():
-    pass
+def record_empty_title(context):
+    context["raw_data"] = RawEdital(
+        title="",
+        url="http://mock.com"
+    )
+    if not context.get("transform_engine"):
+        context["transform_engine"] = EditalNormalizer()
 
 @when('the Transform component attempts validation')
-def transform_attempts_validation():
-    pass
+def transform_attempts_validation(context):
+    try:
+        context["result"] = context["transform_engine"].process(context["raw_data"])
+    except ValueError as e:
+        context["error"] = e
 
 @then('a validation error should occur')
-def validation_error_occurs():
-    pass
+def validation_error_occurs(context):
+    assert isinstance(context["error"], ValueError)
 
 @then('the record should be explicitly dropped from the pipeline')
-def record_dropped():
-    pass
+def record_dropped(context):
+    # Validation error ensures dropping
+    assert context.get("result") is None


### PR DESCRIPTION
Resolve #4

### O que foi feito
- Criado o componente de domínio focado em transformação `EditalNormalizer`.
- Construído acoplamento com regex para higienização de quebras de linha/espaços sobressalentes no título.
- Implementado sistema empírico de Categorização do edital (`"Extensão"`, `"Pesquisa"`, `"Inovação"` ou `"Outros"`) lendo o conteúdo raw.
- Integrado o motor de transform aos testes comportamentais Gherkin (BDD), que cobriram classificação por palavra-chave corretamente e garantem retorno em domínio `EditalDomain`.
- Falha sintética de Validação (Ex: Sem título) bloqueando propagação no pipeline com erro `ValueError`.